### PR TITLE
Adjust only the last used input of mutations probability

### DIFF
--- a/src/Hyperparameters.js
+++ b/src/Hyperparameters.js
@@ -16,6 +16,8 @@ const Hyperparams = {
         this.addProb = 33;
         this.changeProb = 33;
         this.removeProb = 33;
+        // 1 add, 2 change, 3 remove
+        this.addChReProbPrio = [3, 2, 1]
         
         this.moversCanRotate = true;
         this.offspringRotate = true;
@@ -31,20 +33,45 @@ const Hyperparams = {
     },
 
     balanceMutationProbs : function(choice) {
-        if (choice == 1) {
-            var remaining = 100 - this.addProb;
-            this.changeProb = remaining/2;
-            this.removeProb = remaining/2;
-        }
-        else if (choice == 2) {
-            var remaining = 100 - this.changeProb;
-            this.addProb = remaining/2;
-            this.removeProb = remaining/2;
-        }
-        else {
-            var remaining = 100 - this.removeProb;
-            this.changeProb = remaining/2;
-            this.addProb = remaining/2;
+        
+        // Move to last
+        this.addChReProbPrio.push(this.addChReProbPrio.splice(this.addChReProbPrio.indexOf(choice), 1)[0]);
+        
+        // If last used (first in list) was addProb, add to it.
+        if (this.addChReProbPrio[0] == 1) {
+            // If it is enough to change the addProb
+            if ((this.changeProb + this.removeProb) <= 100) {
+                this.addProb = 100 - this.changeProb - this.removeProb;
+            } else {
+                // Isn't enough, we need to change the other too
+                this.addProb = 0
+                if (this.addChReProbPrio[1] == 2) {
+                    this.this.changeProb = 100 - this.removeProb;
+                } else {
+                    this.this.removeProb = 100 - this.changeProb;
+                }
+        } else if (this.addChReProbPrio[0] == 2) {
+            if ((this.addProb + this.removeProb) <= 100) {
+                this.changeProb = 100 - this.addProb - this.removeProb;
+            } else {
+                this.changeProb = 0;
+                if (this.addChReProbPrio[1] == 1) {
+                    this.addProb = 100 - this.removeProb;
+                } else {
+                    this.addRemove = 100 - this.addProb;
+                }
+            }
+        } else if (this.addChReProbPrio[0] == 3) {
+            if ((this.addProb + this.changeProb) <= 100) {
+                this.removeProb = 100 - this.addProb - this.changeProb;
+            } else {
+                this.removeProb = 0;
+                if (this.addChReProbPrio[1] == 1) {
+                    this.addProb = 100 - this.changeProb;
+                } else {
+                    this.changeProb = 100 - this.addProb;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This fixed #19 by having a list of the last edited mutation probability and setting the remainder to the last used or if it isn't enough, setting it to 0 and the other to the remainder.