### PR TITLE
Quality of life changes

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -19,12 +19,12 @@
 		<div class='control-panel'>
 			<div id='speed-controller' class='control-set'>
 				<div class='vertical-buttons'>
-					<button class="reset-view" title="Reset View"><i class="fa fa-video-camera"></i></button>
-					<button class="edit-mode-btn" id="drag-view" title="Drag View"><i class="fa fa-arrows"></i></button>
-					<button class="edit-mode-btn" id="wall-drop" title="Drop/Remove Wall"><i class="fa fa-square"></i></button>
-					<button class="edit-mode-btn" id="food-drop" title="Drop/Remove Food"><i class="fa fa-cutlery"></i></button>
-					<button class="edit-mode-btn" id="click-kill" title="Click to kill"><i class="fa fa-bolt"></i></button>
-					<button id="clear-walls" title="Clear All Walls"><i class="fa fa-window-close"></i></button>
+					<button class="reset-view" title="Reset View. Hotkey: 1"><i class="fa fa-video-camera"></i></button>
+					<button class="edit-mode-btn drag-view" id="drag-view" title="Drag View. Hotkey: 2"><i class="fa fa-arrows"></i></button>
+					<button class="edit-mode-btn wall-drop" id="wall-drop" title="Drop/Remove Wall. Hotkey: 3"><i class="fa fa-square"></i></button>
+					<button class="edit-mode-btn food-drop" id="food-drop" title="Drop/Remove Food. Hotkey: 4"><i class="fa fa-cutlery"></i></button>
+					<button class="edit-mode-btn click-kill" id="click-kill" title="Click to kill. Hotkey: 5"><i class="fa fa-bolt"></i></button>
+					<button id="clear-walls" title="Clear All Walls. Hotkey: x"><i class="fa fa-window-close"></i></button>
 				</div>
 				<h2>Simulation Speed</h2>
 				<input id="slider" type="range" min="1" max="300" value="60">
@@ -62,7 +62,7 @@
 					<p class='tabnav-item' id='hyperparameters'>Simulation Controls</p>
 					<p class='tabnav-item' id='stats'>Stats</p>
 					<p class='tabnav-item' id='challenges'>Challenges</p>
-					<button id="minimize" title="Minimze Control Panel"><i class="fa fa-minus-square"></i></button>
+					<button id="minimize" title="Minimze Control Panel. Hotkey: i"><i class="fa fa-minus-square"></i></button>
 				</div>
 
 				<div id='about' class='tab'>
@@ -98,9 +98,9 @@
 				<div id='editor' class='tab'>
 					<div class='left-half' id='editor-panel'>
 						<div class='editor-buttons'>
-							<button class="edit-mode-btn" id="select" title="Select organism from world"><i class="fa fa-hand-pointer-o"></i></button>
-							<button class="edit-mode-btn" id="edit" title="Edit organism"><i class="fa fa-pencil"></i></button>
-							<button class="edit-mode-btn" id="drop-org" title="Drop organism in world"><i class="fa fa-plus"></i></button>
+							<button class="edit-mode-btn select" id="select" title="Select organism from world. Hotkey: s"><i class="fa fa-hand-pointer-o"></i></button>
+							<button class="edit-mode-btn edit" id="edit" title="Edit organism. Hotkey: e"><i class="fa fa-pencil"></i></button>
+							<button class="edit-mode-btn drop-org" id="drop-org" title="Drop organism in world. Hotkey: d"><i class="fa fa-plus"></i></button>
 						</div>
 						<div id='editor-env'>
 							<canvas id='editor-canvas'></canvas>
@@ -261,19 +261,19 @@
 			</div>
 		</div>
 		<div class='hot-controls'>
-			<button class="reset-view" title="Reset View"><i class="fa fa-video-camera"></i></button>
-			<button class="edit-mode-btn" id="drag-view" title="Drag View"><i class="fa fa-arrows"></i></button>
-			<button class="edit-mode-btn" id="wall-drop" title="Drop/Remove Wall"><i class="fa fa-square"></i></button>
-			<button class="edit-mode-btn" id="food-drop" title="Drop/Remove Food"><i class="fa fa-cutlery"></i></button>
-			<button class="edit-mode-btn" id="click-kill" title="Click to kill"><i class="fa fa-bolt"></i></button>
-			<button class='pause-button'><i class="fa fa-pause"></i></button>
-			<button class="headless" title="Toggle rendering"><i class="fa fa-eye-slash"></i></button>
+			<button class="reset-view" title="Reset View. Hotkey: 1"><i class="fa fa-video-camera"></i></button>
+			<button class="edit-mode-btn drag-view" id="drag-view" title="Drag View. Hotkey: 2"><i class="fa fa-arrows"></i></button>
+			<button class="edit-mode-btn wall-drop" id="wall-drop" title="Drop/Remove Wall. Hotkey: 3"><i class="fa fa-square"></i></button>
+			<button class="edit-mode-btn food-drop" id="food-drop" title="Drop/Remove Food. Hotkey: 4"><i class="fa fa-cutlery"></i></button>
+			<button class="edit-mode-btn click-kill" id="click-kill" title="Click to kill. Hotkey: 5"><i class="fa fa-bolt"></i></button>
+			<button class='pause-button' title="Play/Pause. Hotkey: 6"><i class="fa fa-pause"></i></button>
+			<button class="headless" title="Toggle rendering. Hotkey: 7"><i class="fa fa-eye-slash"></i></button>
 		</div>
 		<div id="headless-notification">
 			<i class="fa fa-eye-slash" ></i>
 		</div>
 		<div id='maximize-hot-control' class='hot-controls'>
-			<button id="maximize" title="Show Control Panel"><i class="fa fa-plus-square"></i></button>
+			<button id="maximize" title="Show Control Panel. Hotkey: i"><i class="fa fa-plus-square"></i></button>
 		</div>
 		
 	</body>

--- a/src/Controllers/CanvasController.js
+++ b/src/Controllers/CanvasController.js
@@ -9,6 +9,7 @@ class CanvasController{
         this.mouse_c;
         this.mouse_r;
         this.left_click = false;
+        this.middle_click = false;
         this.right_click = false;
         this.cur_cell = null;
         this.cur_org = null;
@@ -30,16 +31,21 @@ class CanvasController{
             evt.preventDefault();
             this.updateMouseLocation(evt.offsetX, evt.offsetY)
             this.mouseUp();
-            this.left_click=false;
-            this.right_click=false;
+            if (evt.button == 0) 
+                this.left_click = false;
+            if (evt.button == 1) 
+                this.middle_click = false;
+            if (evt.button == 2) 
+                this.right_click = false;
         }.bind(this));
 
         this.canvas.addEventListener('mousedown', function(evt) {
             evt.preventDefault();
             this.updateMouseLocation(evt.offsetX, evt.offsetY)
-            if (evt.button == 0) {
+            if (evt.button == 0) 
                 this.left_click = true;
-            }
+            if (evt.button == 1) 
+                this.middle_click = true;
             if (evt.button == 2) 
                 this.right_click = true;
             this.mouseDown();
@@ -50,10 +56,24 @@ class CanvasController{
         });
 
         this.canvas.addEventListener('mouseleave', function(){
-            this.right_click = false;
-            this.left_click = false;
+            this.left_click   = false;
+            this.middle_click = false;
+            this.right_click  = false;
             this.env.renderer.clearAllHighlights(true);
         }.bind(this));
+
+        this.canvas.addEventListener('mouseenter', function(evt) {
+
+            this.left_click   = !!(evt.buttons & 1);
+            this.right_click  = !!(evt.buttons & 2);
+            this.middle_click = !!(evt.buttons & 4);
+
+            this.updateMouseLocation(evt.offsetX, evt.offsetY);
+            this.start_x = this.mouse_x;
+            this.start_y = this.mouse_y;
+
+
+        }.bind(this))
 
     }
 

--- a/src/Controllers/ControlPanel.js
+++ b/src/Controllers/ControlPanel.js
@@ -6,6 +6,7 @@ class ControlPanel {
     constructor(engine) {
         this.engine = engine;
         this.defineMinMaxControls();
+        this.defineHotkeys();
         this.defineEngineSpeedControls();
         this.defineGridSizeControls();
         this.defineTabNavigation();
@@ -41,25 +42,7 @@ class ControlPanel {
                 this.stats_panel.startAutoRender();
             }
         });
-        const V_KEY = 118;
-        $('body').keypress( (e) => {
-            if (e.which === V_KEY) {
-                if (this.no_hud) {
-                    let control_panel_display = this.control_panel_active ? 'grid' : 'none';
-                    let hot_control_display = !this.control_panel_active ? 'block' : 'none';
-                    if (this.control_panel_active && this.tab_id == 'stats') {
-                        this.stats_panel.startAutoRender();
-                    };
-                    $('.control-panel').css('display', control_panel_display);
-                    $('.hot-controls').css('display', hot_control_display);
-                }
-                else {
-                    $('.control-panel').css('display', 'none');
-                    $('.hot-controls').css('display', 'none');
-                }
-                this.no_hud = !this.no_hud;
-            }
-        });
+
         // var self = this;
         // $('#minimize').click ( function() {
         //     $('.control-panel').css('display', 'none');
@@ -73,6 +56,88 @@ class ControlPanel {
         //         self.stats_panel.startAutoRender();
         //     }
         // });
+    }
+
+    defineHotkeys() {
+
+        $('body').keydown( (evt) => {
+
+            //console.log(evt.which);
+
+            switch (evt.which) {
+
+                // hot bar controls
+                case 49: // 1 = Reset Camera
+                    $('.reset-view')[0].click();
+                    break;
+
+                case 50: // 2 = Drag View
+                    $('#drag-view').click();
+                    break;
+
+                case 51: // 3 = Drop Wall
+                    $('#wall-drop').click();
+                    break;
+
+                case 52: // 4 = Drop Food
+                    $('#food-drop').click();
+                    break;
+
+                case 53: // 5 = Kill
+                    $('#click-kill').click();
+                    break;
+
+                case 54: // 6 = Play/Pause
+                case 32: // Space = Play/Pause
+                    $('.pause-button')[0].click();
+                    break;
+
+                case 55: // 7 = Toggle Rendering
+                    $('.headless')[0].click();
+                    break;
+
+                // miscellaneous hotkeys
+                case 9: // tab = toggle control panel
+                    evt.preventDefault();
+                    if (this.control_panel_active)
+                        $('#minimize').click();
+                    else
+                        $('#maximize').click();
+                    break;
+
+                case 68: // d = drop organism
+                    $('#drop-org').click();
+                    break;
+
+                case 69: // e = edit organism
+                    $('#edit').click();
+                    break;
+
+                case 83: // s = select creature mode
+                    $('#select').click();
+                    break;
+
+                case 86: // v = Toggle HUD
+                    if (this.no_hud) {
+                        let control_panel_display = this.control_panel_active ? 'grid' : 'none';
+                        let hot_control_display = !this.control_panel_active ? 'block' : 'none';
+                        if (this.control_panel_active && this.tab_id == 'stats') {
+                            this.stats_panel.startAutoRender();
+                        };
+                        $('.control-panel').css('display', control_panel_display);
+                        $('.hot-controls').css('display', hot_control_display);
+                    }
+                    else {
+                        $('.control-panel').css('display', 'none');
+                        $('.hot-controls').css('display', 'none');
+                    }
+                    this.no_hud = !this.no_hud;
+                    break;
+
+                case 88: // x = clear all walls
+                    $('#clear-walls').click();
+            }
+        });
     }
 
     defineEngineSpeedControls(){
@@ -261,20 +326,15 @@ class ControlPanel {
                     break;
                 case "edit":
                     self.setMode(Modes.Edit);
-                    self.editor_controller.setEditorPanel();
                     break;
                 case "drop-org":
                     self.setMode(Modes.Clone);
-                    self.env_controller.org_to_clone = self.engine.organism_editor.getCopyOfOrg();
-                    self.env_controller.add_new_species = self.editor_controller.new_species;
-                    self.editor_controller.new_species = false;
-                    // console.log(self.env_controller.add_new_species)
                     break;
                 case "drag-view":
                     self.setMode(Modes.Drag);
             }
             $('.edit-mode-btn').css('background-color', '#9099c2');
-            $('#'+this.id).css('background-color', '#81d2c7');
+            $('.'+this.id).css('background-color', '#81d2c7');
         });
 
         $('.reset-view').click( function(){
@@ -310,6 +370,17 @@ class ControlPanel {
     setMode(mode) {
         this.env_controller.mode = mode;
         this.editor_controller.mode = mode;
+
+        if (mode == Modes.Edit) {
+            this.editor_controller.setEditorPanel();
+        }
+
+        if (mode == Modes.Clone) {
+            this.env_controller.org_to_clone = this.engine.organism_editor.getCopyOfOrg();
+            this.env_controller.add_new_species = this.editor_controller.new_species;
+            this.editor_controller.new_species = false;
+            // console.log(this.env_controller.add_new_species)
+        }
     }
 
     setEditorOrganism(org) {

--- a/src/Controllers/EnvironmentController.js
+++ b/src/Controllers/EnvironmentController.js
@@ -28,22 +28,33 @@ class EnvironmentController extends CanvasController{
             // Restrict scale
             scale = Math.max(0.5, this.scale+(sign*zoom_speed));
 
-            if (scale != 0.5) {
+            //if (scale != 0.5) {
+
                 var cur_top = parseInt($('#env-canvas').css('top'));
                 var cur_left = parseInt($('#env-canvas').css('left'));
+
+                var diff_x = (this.canvas.width/2  - this.mouse_x) * (scale - this.scale);
+                var diff_y = (this.canvas.height/2 - this.mouse_y) * (scale - this.scale);
+
+                /* -- Original Zoom procedure
                 if (sign == 1) {
                     // If we're zooming in, zoom towards wherever the mouse is
-                    var diff_x = ((this.canvas.width/2-cur_left/this.scale) - this.mouse_x)*this.scale/1.5;
-                    var diff_y = ((this.canvas.height/2-cur_top/this.scale) - this.mouse_y)*this.scale/1.5;
+                    var diff_x = ((this.canvas.width/2-cur_left/this.scale) - this.mouse_x)*scale/1.5;
+                    var diff_y = ((this.canvas.height/2-cur_top/this.scale) - this.mouse_y)*scale/1.5;
+
                 }
                 else {
                     // If we're zooming out, zoom out towards the center
                     var diff_x = -cur_left/scale;
                     var diff_y = -cur_top/scale;
+                    var new_left = cur_left - cur_left / scale;
+                    var new_top  = cur_top  - cur_top  / scale;
                 }
+                */
+
                 $('#env-canvas').css('top', (cur_top+diff_y)+'px');
                 $('#env-canvas').css('left', (cur_left+diff_x)+'px');
-            }
+            //}
           
             // Apply scale transform
             el.style.transform = `scale(${scale})`;
@@ -148,6 +159,15 @@ class EnvironmentController extends CanvasController{
                     $('#env-canvas').css('left', new_left+'px');
                     break;
             }
+        }
+        else if (this.middle_click) {
+            //drag on middle click
+            var cur_top = parseInt($('#env-canvas').css('top'), 10);
+            var cur_left = parseInt($('#env-canvas').css('left'), 10);
+            var new_top = cur_top + ((this.mouse_y - this.start_y)*this.scale);
+            var new_left = cur_left + ((this.mouse_x - this.start_x)*this.scale);
+            $('#env-canvas').css('top', new_top+'px');
+            $('#env-canvas').css('left', new_left+'px');
         }
     }
 


### PR DESCRIPTION
### Hotkeys
Hotkeys for the buttons on the hotbar are assigned to the numbers 1-7
![hotkeys](https://user-images.githubusercontent.com/13613122/143198402-d4e22f6d-bc2d-4ac0-b354-c88f53b0e94b.png)

Additional Hotkeys:
|   Action   |   Hotkey  |
| ---------- | ---------- |
| Play/Pause | Space |
| Minimize/Maximize Control Panel | Tab |
| Toggle HUD visibility | v |
| Select Organism Mode | s |
| Edit Organism Mode | e |
| Drop Organism Mode | d |
| Clear All Walls | x |

---
### Consistent Zooming
Zooming now keeps the point under the mouse exactly in the same spot, so zooming in and zooming out are exact inverses of each other.

---
### Better handling of mouse enter
The program now checks the state of the mouse buttons on mouse enter, so if you drag the mouse out of the window and back in, it continues your action.

---
### Middle-click for drag
Holding middle-click on the mouse now allows you to drag the screen as if you were in Drag View Mode. This allows users to navigate without having to constantly switching modes.

---
### Fixed hotbar bug
The UI buttons on the hotbar would not light up when the user switched to its respective Control Mode, but the ones on the control panel would. Now both buttons light up when in the given mode.