### PR TITLE
Skip frames option to keep rendering w/o performance issues.

### DIFF
--- a/dist/css/style.css
+++ b/dist/css/style.css
@@ -280,3 +280,7 @@ button:active{
 #reset-with-editor-org{
     margin-top: 5px;
 }
+
+#skip-frames-number{
+    width: 30px;
+}

--- a/dist/index.html
+++ b/dist/index.html
@@ -31,7 +31,9 @@
 				<button class='pause-button' title="Play/Pause. Hotkey: Spacebar"><i class="fa fa-pause"></i></button>
 				<button class="headless" title="Toggle rendering. Hotkey: H"><i class="fa fa-eye-slash"></i></button>
 				<div>
-				<label class="skip-frames-label" title="Run the simulation with targeted fps in the backend, but skip the frames to display 30fps. Hotkey: J" for="skip-frames">Skip Frames (30fps Time-lapse)</label>
+				<label class="skip-frames-label" title="Skip the entered number of frames every time before render. Hotkey: J" for="skip-frames">
+					Skip Every <input type="number" id="skip-frames-number" min="0" max="1000" value=4 step="1"> Frames 
+				</label>
 				<input id="skip-frames" type="checkbox">
 				</div>
 				<p id='fps'>Target FPS: 60</p>

--- a/dist/index.html
+++ b/dist/index.html
@@ -30,6 +30,10 @@
 				<input id="slider" type="range" min="1" max="300" value="60">
 				<button class='pause-button' title="Play/Pause. Hotkey: Spacebar"><i class="fa fa-pause"></i></button>
 				<button class="headless" title="Toggle rendering. Hotkey: H"><i class="fa fa-eye-slash"></i></button>
+				<div>
+				<label class="skip-frames-label" title="Run the simulation with targeted fps in the backend, but skip the frames to display 30fps. Hotkey: J" for="skip-frames">Skip Frames (30fps Time-lapse)</label>
+				<input id="skip-frames" type="checkbox">
+				</div>
 				<p id='fps'>Target FPS: 60</p>
 				<p id='fps-actual'></p>
 				<button id='reset-env' title='Restarts simulation with default organism.'>Reset</button>

--- a/src/Controllers/ControlPanel.js
+++ b/src/Controllers/ControlPanel.js
@@ -145,6 +145,7 @@ class ControlPanel {
             }
             //disable skip frames checkbox
             $('#skip-frames').prop('disabled', !WorldConfig.headless);
+            $('#skip-frames-number').prop('disabled', !WorldConfig.headless);
             $('.skip-frames-label').css('color', WorldConfig.headless ? 'black' : 'gray');
             WorldConfig.headless = !WorldConfig.headless;
         }.bind(this));
@@ -152,6 +153,10 @@ class ControlPanel {
         $('#skip-frames').click(function() {
             WorldConfig.skip_frames = !WorldConfig.skip_frames;
             $('#skip-frames').prop('checked', WorldConfig.skip_frames);
+        }.bind(this));
+
+        $('#skip-frames-number').change(function() {
+            this.engine.render_period = parseInt($('#skip-frames-number').val()) || 0;
         }.bind(this));
     }
 
@@ -473,7 +478,7 @@ class ControlPanel {
 
     update(delta_time) {
         if(WorldConfig.skip_frames && !WorldConfig.headless) {
-            $('#fps-actual').text("Actual FPS: " + Math.floor(this.engine.actual_fps/this.engine.render_period) + " (" + Math.floor(this.engine.actual_fps) + ")");
+            $('#fps-actual').text("Actual FPS: " + Math.floor(this.engine.skipped_fps) + " (" + Math.floor(this.engine.actual_fps) + ")");
         }else{
             $('#fps-actual').text("Actual FPS: " + Math.floor(this.engine.actual_fps));
         }

--- a/src/Controllers/ControlPanel.js
+++ b/src/Controllers/ControlPanel.js
@@ -69,6 +69,9 @@ class ControlPanel {
                     $('.headless')[0].click();
                     break;
                 case 'j':
+                    $('#skip-frames').click();
+                    break;
+                case 'k':
                 case ' ':
                     e.preventDefault();
                     $('.pause-button')[0].click();
@@ -140,7 +143,15 @@ class ControlPanel {
             else {
                 $('#headless-notification').css('display', 'block');
             }
+            //disable skip frames checkbox
+            $('#skip-frames').prop('disabled', !WorldConfig.headless);
+            $('.skip-frames-label').css('color', WorldConfig.headless ? 'black' : 'gray');
             WorldConfig.headless = !WorldConfig.headless;
+        }.bind(this));
+
+        $('#skip-frames').click(function() {
+            WorldConfig.skip_frames = !WorldConfig.skip_frames;
+            $('#skip-frames').prop('checked', WorldConfig.skip_frames);
         }.bind(this));
     }
 
@@ -461,7 +472,11 @@ class ControlPanel {
     }
 
     update(delta_time) {
-        $('#fps-actual').text("Actual FPS: " + Math.floor(this.engine.actual_fps));
+        if(WorldConfig.skip_frames && !WorldConfig.headless) {
+            $('#fps-actual').text("Actual FPS: " + Math.floor(this.engine.actual_fps/this.engine.render_period) + " (" + Math.floor(this.engine.actual_fps) + ")");
+        }else{
+            $('#fps-actual').text("Actual FPS: " + Math.floor(this.engine.actual_fps));
+        }
         $('#reset-count').text("Auto reset count: " + this.engine.env.reset_count);
         this.stats_panel.updateDetails();
         if (WorldConfig.headless)

--- a/src/Engine.js
+++ b/src/Engine.js
@@ -2,6 +2,7 @@ const WorldEnvironment = require('./Environments/WorldEnvironment');
 const ControlPanel = require('./Controllers/ControlPanel');
 const OrganismEditor = require('./Environments/OrganismEditor');
 const ColorScheme = require('./Rendering/ColorScheme');
+const WorldConfig = require('./WorldConfig');
 
 // If the simulation speed is below this value, a new interval will be created to handle ui rendering
 // at a reasonable speed. If it is above, the simulation interval will be used to update the ui.
@@ -24,6 +25,7 @@ class Engine {
         this.ui_delta_time = 0;
 
         this.actual_fps = 0;
+        this.render_period = 1;
         this.running = false;
     }
 
@@ -80,6 +82,15 @@ class Engine {
 
     environmentUpdate() {
         this.actual_fps = (1000/this.sim_delta_time);
+        
+        if(WorldConfig.skip_frames){
+            this.render_period = Math.floor(this.actual_fps/30);
+            if(this.render_period <= 1) this.render_period = Math.floor(this.fps/30);//if fps is too low to decide on render period, just use fps
+            if(this.render_period <= 0) this.render_period = 1;//division with 0 is undefined
+        }else{
+            this.render_period = 1;
+        }
+
         this.env.update(this.sim_delta_time);
         if(this.ui_loop == null) {
             this.necessaryUpdate();

--- a/src/Engine.js
+++ b/src/Engine.js
@@ -25,7 +25,8 @@ class Engine {
         this.ui_delta_time = 0;
 
         this.actual_fps = 0;
-        this.render_period = 1;
+        this.render_period = 4;
+        this.skipped_fps = 0;
         this.running = false;
     }
 
@@ -84,11 +85,9 @@ class Engine {
         this.actual_fps = (1000/this.sim_delta_time);
         
         if(WorldConfig.skip_frames){
-            this.render_period = Math.floor(this.actual_fps/30);
-            if(this.render_period <= 1) this.render_period = Math.floor(this.fps/30);//if fps is too low to decide on render period, just use fps
-            if(this.render_period <= 0) this.render_period = 1;//division with 0 is undefined
+            this.skipped_fps = this.actual_fps/this.render_period;
         }else{
-            this.render_period = 1;
+            this.skipped_fps = 0;
         }
 
         this.env.update(this.sim_delta_time);

--- a/src/Environments/WorldEnvironment.js
+++ b/src/Environments/WorldEnvironment.js
@@ -50,10 +50,9 @@ class WorldEnvironment extends Environment{
             return;
         }
 
-        //skip frames to match 30 fps
-        var render_period = this.controller.control_panel.engine.render_period;
+        var render_period = WorldConfig.skip_frames ? this.controller.control_panel.engine.render_period : 1;
 
-        if(this.total_ticks % render_period != 0) return;
+        if(this.total_ticks % (render_period + 1) != 0) return;
 
         this.renderer.renderCells();
         this.renderer.renderHighlights();

--- a/src/Environments/WorldEnvironment.js
+++ b/src/Environments/WorldEnvironment.js
@@ -49,6 +49,12 @@ class WorldEnvironment extends Environment{
             this.renderer.cells_to_render.clear();
             return;
         }
+
+        //skip frames to match 30 fps
+        var render_period = this.controller.control_panel.engine.render_period;
+
+        if(this.total_ticks % render_period != 0) return;
+
         this.renderer.renderCells();
         this.renderer.renderHighlights();
     }

--- a/src/WorldConfig.js
+++ b/src/WorldConfig.js
@@ -1,5 +1,6 @@
 const WorldConfig = {
     headless: false,
+    skip_frames: false,
     clear_walls_on_reset: false,
     auto_reset: true,
     auto_pause: false,


### PR DESCRIPTION
![skip-frames](https://user-images.githubusercontent.com/29312699/149832865-53bcd610-4d1a-4446-b110-feffcd2ec084.gif)

The specified amount of frames is skipped before each render, making it possible to render without performance problems.