### PR TITLE
Mutability of Mutation Type Probabilities (Add, Change, Remove)

### DIFF
--- a/dist/css/style.css
+++ b/dist/css/style.css
@@ -280,3 +280,7 @@ button:active{
 #reset-with-editor-org{
     margin-top: 5px;
 }
+
+input[type=number]{
+    max-width: 47px;
+}

--- a/dist/index.html
+++ b/dist/index.html
@@ -106,7 +106,8 @@
 							<p class='cell-count'>Cell count: </p>
 							<p id='move-range'>Move Range: </p>
 							<p id='mutation-rate'>Mutation Rate: </p>
-							<br>
+							<h4 title='When an organism mutates, it can choose from one of the following mutation types.'>Mutation Type Probabilities</h4>
+							<p id='mutation-probs'>Add: 34, Change: 33, Remove: 33</p>
 						
 							<div class='brain-details'>
 								<h4>Brain</h4>
@@ -221,14 +222,6 @@
 						<input type="checkbox" id="evolved-mutation" checked> </br>
 						<label class="global-mutation-in" for="global-mutation">Global mutation rate: </label>
 						<input class="global-mutation-in" type="number" id="global-mutation" min="1" max="100" value=5 step="1">
-						<h4 title='When an organism mutates, it can choose from one of the following mutation types.'>Mutation Type Probabilities</h4>
-						<label for="add-prob" title='A new cell will stem from an existing one'>Add Cell:</label>
-						<input class="mut-prob" type="number" id="add-prob" min="0" max="100" value=33>
-						<label for="change-prob" title='A currently existing cell will change its color.'>Change Cell:</label>
-						<input class="mut-prob" type="number" id="change-prob" min="0" max="100" value=33>
-						<label for="remove-prob" title='An existing cell will be removed.'>Remove Cell:</label>
-						<input class="mut-prob" type="number" id="remove-prob" min="0" max="100" value=33>
-						<br/>
 						<label for="movers-produce" title='When on, movers can produce food from producer cells. When off, producer cells are disabled on mover organisms.'>Movers can produce food</label>
 						<input type="checkbox" id="movers-produce">
 						<br/>
@@ -252,7 +245,7 @@
 						<select name="chart-option" id="chart-option">
 							<option value="population">Population</option>
 							<option value="species">Species</option>
-							<option value="mut-rate">Organism Structure</option>
+							<option value="org-structure">Organism Structure</option>
 							<option value="mut-rate">Mutation Rate</option>
 						</select>
 						<p id='chart-note'></p>

--- a/dist/index.html
+++ b/dist/index.html
@@ -105,9 +105,9 @@
 							<h3>Organism Details</h3>
 							<p class='cell-count'>Cell count: </p>
 							<p id='move-range'>Move Range: </p>
-							<p id='mutation-rate'>Mutation Rate: </p>
-							<h4 title='When an organism mutates, it can choose from one of the following mutation types.'>Mutation Type Probabilities</h4>
-							<p id='mutation-probs'>Add: 34, Change: 33, Remove: 33</p>
+							<p>
+								<span id='mutation-rate'>Mutation Rate: </span><span id='mutation-probs'> (Add: 33, Change: 33, Remove: 33)</span>
+							</p>
 						
 							<div class='brain-details'>
 								<h4>Brain</h4>
@@ -126,6 +126,15 @@
 							<div id='mutation-rate-cont'>
 								<label for="mutation-rate-edit" title='Probability that offspring of this organism will mutate'>Mutation Rate:</label>
 								<input type="number" id="mutation-rate-edit" min="1" max="100" value=3 step="1">
+								<span> (</span>
+								<label for="mutation-add-edit" title='Probability that offspring of this organism will add a cell'>Add:</label>
+								<input type="number" id="mutation-add-edit" min="1" max="100" value=33 step="1">
+								<label for="mutation-change-edit" title='Probability that offspring of this organism will change a cell'>Change:</label>
+								<input type="number" id="mutation-change-edit" min="1" max="100" value=33 step="1">
+								<label for="mutation-remove-edit" title='Probability that offspring of this organism will remove a cell'>Remove:</label>
+								<input type="number" id="mutation-remove-edit" min="1" max="100" value=33 step="1">
+								<span> )</span>
+								
 							</div>
 							<!-- <br> -->
 							<div class='brain-details'>

--- a/src/Controllers/ControlPanel.js
+++ b/src/Controllers/ControlPanel.js
@@ -246,22 +246,6 @@ class ControlPanel {
         $('#global-mutation').change( function() {
             Hyperparams.globalMutability = parseInt($('#global-mutation').val());
         });
-        $('.mut-prob').change( function() {
-            switch(this.id){
-                case "add-prob":
-                    Hyperparams.addProb = this.value;
-                    break;
-                case "change-prob":
-                    Hyperparams.changeProb = this.value;
-                    break;
-                case "remove-prob":
-                    Hyperparams.removeProb = this.value;
-                    break;
-            }
-            $('#add-prob').val(Math.floor(Hyperparams.addProb));
-            $('#change-prob').val(Math.floor(Hyperparams.changeProb));
-            $('#remove-prob').val(Math.floor(Hyperparams.removeProb));
-        });
         $('#movers-produce').change( function() {
             Hyperparams.moversCanProduce = this.checked;
         });
@@ -307,9 +291,6 @@ class ControlPanel {
         $('#rot-enabled').prop('checked', Hyperparams.rotationEnabled);
         $('#insta-kill').prop('checked', Hyperparams.instaKill);
         $('#evolved-mutation').prop('checked', !Hyperparams.useGlobalMutability);
-        $('#add-prob').val(Hyperparams.addProb);
-        $('#change-prob').val(Hyperparams.changeProb);
-        $('#remove-prob').val(Hyperparams.removeProb);
         $('#movers-produce').prop('checked', Hyperparams.moversCanProduce);
         $('#food-blocks').prop('checked', Hyperparams.foodBlocksReproduction);
         $('#food-drop-rate').val(Hyperparams.foodDropProb);

--- a/src/Controllers/EditorController.js
+++ b/src/Controllers/EditorController.js
@@ -129,7 +129,7 @@ class EditorController extends CanvasController{
         $('.cell-count').text("Cell count: "+org.anatomy.cells.length);
         $('#move-range').text("Move Range: "+org.move_range);
         $('#mutation-rate').text("Mutation Rate: "+org.mutability);
-        $('#mutation-probs').text("Add: "+org.addProb+", Change: "+org.changeProb+", Remove: "+org.removeProb);
+        $('#mutation-probs').text("Add: "+org.addProb.toFixed(2)+", Change: "+org.changeProb.toFixed(2)+", Remove: "+org.removeProb.toFixed(2));
        
 		if (Hyperparams.useGlobalMutability) {
             $('#mutation-rate').css('display', 'none');

--- a/src/Controllers/EditorController.js
+++ b/src/Controllers/EditorController.js
@@ -129,6 +129,7 @@ class EditorController extends CanvasController{
         $('.cell-count').text("Cell count: "+org.anatomy.cells.length);
         $('#move-range').text("Move Range: "+org.move_range);
         $('#mutation-rate').text("Mutation Rate: "+org.mutability);
+        $('#mutation-probs').text("Add: "+org.addProb+", Change: "+org.changeProb+", Remove: "+org.removeProb);
        
 		if (Hyperparams.useGlobalMutability) {
             $('#mutation-rate').css('display', 'none');

--- a/src/Controllers/EditorController.js
+++ b/src/Controllers/EditorController.js
@@ -97,6 +97,19 @@ class EditorController extends CanvasController{
         $('#mutation-rate-edit').change ( function() {
             this.env.organism.mutability = parseInt($('#mutation-rate-edit').val());
         }.bind(this));
+
+        $('#mutation-add-edit').change ( function() {
+            this.env.organism.addProb = parseFloat($('#mutation-add-edit').val());
+        }.bind(this));
+
+        $('#mutation-change-edit').change ( function() {
+            this.env.organism.changeProb = parseFloat($('#mutation-change-edit').val());
+        }.bind(this));
+
+        $('#mutation-remove-edit').change ( function() {
+            this.env.organism.removeProb = parseFloat($('#mutation-remove-edit').val());
+        }.bind(this));
+
         $('#observation-type-edit').change ( function() {
             this.setBrainEditorValues($('#observation-type-edit').val());
             this.setBrainDetails();
@@ -129,13 +142,13 @@ class EditorController extends CanvasController{
         $('.cell-count').text("Cell count: "+org.anatomy.cells.length);
         $('#move-range').text("Move Range: "+org.move_range);
         $('#mutation-rate').text("Mutation Rate: "+org.mutability);
-        $('#mutation-probs').text("Add: "+org.addProb.toFixed(2)+", Change: "+org.changeProb.toFixed(2)+", Remove: "+org.removeProb.toFixed(2));
+        $('#mutation-probs').text(" (Add: "+org.addProb.toFixed(2)+", Change: "+org.changeProb.toFixed(2)+", Remove: "+org.removeProb.toFixed(2)+")");
        
 		if (Hyperparams.useGlobalMutability) {
             $('#mutation-rate').css('display', 'none');
         }
         else {
-            $('#mutation-rate').css('display', 'block');
+            $('#mutation-rate').css('display', 'inline');
         }
 
         this.setMoveRangeVisibility();
@@ -157,6 +170,10 @@ class EditorController extends CanvasController{
         }
 
 		$('#mutation-rate-edit').val(org.mutability);
+        $('#mutation-add-edit').val(org.addProb);
+        $('#mutation-change-edit').val(org.changeProb);
+        $('#mutation-remove-edit').val(org.removeProb);
+
         if (Hyperparams.useGlobalMutability) {
 			$('#mutation-rate-cont').css('display', 'none');
         }

--- a/src/Environments/WorldEnvironment.js
+++ b/src/Environments/WorldEnvironment.js
@@ -19,6 +19,9 @@ class WorldEnvironment extends Environment{
         this.organisms = [];
         this.walls = [];
         this.total_mutability = 0;
+        this.total_add_mutability = 0;
+        this.total_change_mutability = 0;
+        this.total_remove_mutability = 0;
         this.largest_cell_count = 0;
         this.reset_count = 0;
         this.total_ticks = 0;
@@ -61,6 +64,9 @@ class WorldEnvironment extends Environment{
         let start_pop = this.organisms.length;
         for (var i of org_indeces.reverse()){
             this.total_mutability -= this.organisms[i].mutability;
+            this.total_add_mutability -= this.organisms[i].addProb;
+            this.total_change_mutability -= this.organisms[i].changeProb;
+            this.total_remove_mutability -= this.organisms[i].removeProb;
             this.organisms.splice(i, 1);
         }
         if (this.organisms.length === 0 && start_pop > 0) {
@@ -86,6 +92,9 @@ class WorldEnvironment extends Environment{
     addOrganism(organism) {
         organism.updateGrid();
         this.total_mutability += organism.mutability;
+        this.total_add_mutability += organism.addProb;
+        this.total_change_mutability += organism.changeProb;
+        this.total_remove_mutability += organism.removeProb;
         this.organisms.push(organism);
         if (organism.anatomy.cells.length > this.largest_cell_count) 
             this.largest_cell_count = organism.anatomy.cells.length;
@@ -98,6 +107,24 @@ class WorldEnvironment extends Environment{
             return Hyperparams.globalMutability;
         }
         return this.total_mutability / this.organisms.length;
+    }
+
+    avarageAddMutability() {
+        if (this.organisms.length < 1)
+            return 0;
+        return this.total_add_mutability / this.organisms.length;
+    }
+
+    avarageChangeMutability() {
+        if (this.organisms.length < 1)
+            return 0;
+        return this.total_change_mutability / this.organisms.length;
+    }
+    
+    avarageRemoveMutability() {
+        if (this.organisms.length < 1)
+            return 0;
+        return this.total_remove_mutability / this.organisms.length;
     }
 
     changeCell(c, r, state, owner) {
@@ -144,6 +171,9 @@ class WorldEnvironment extends Environment{
         this.grid_map.fillGrid(CellStates.empty, !WorldConfig.clear_walls_on_reset);
         this.renderer.renderFullGrid(this.grid_map.grid);
         this.total_mutability = 0;
+        this.total_add_mutability = 0;
+        this.total_change_mutability = 0;
+        this.total_remove_mutability = 0;
         this.total_ticks = 0;
         FossilRecord.clear_record();
         if (reset_life)

--- a/src/Hyperparameters.js
+++ b/src/Hyperparameters.js
@@ -10,9 +10,6 @@ const Hyperparams = {
 
         this.useGlobalMutability = false;
         this.globalMutability = 5;
-        this.addProb = 33;
-        this.changeProb = 33;
-        this.removeProb = 33;
         
         this.rotationEnabled = true;
 

--- a/src/Organism/Organism.js
+++ b/src/Organism/Organism.js
@@ -87,19 +87,19 @@ class Organism {
             var amount;
             //mutate the add probability
             amount = Math.random()*4 - 2;
-            org.addProb += amount.toFixed(2);
+            org.addProb += amount;
             org.addProb = Math.min(Math.max(org.addProb, 0), 100);
             org.changeProb = 100 - org.addProb - org.removeProb;
             org.removeProb = 100 - org.addProb - org.changeProb;
             //mutate the change probability
             amount = Math.random()*4 - 2;
-            org.changeProb += amount.toFixed(2);
+            org.changeProb += amount;
             org.changeProb = Math.min(Math.max(org.changeProb, 0), 100);
             org.addProb = 100 - org.changeProb - org.removeProb;
             org.removeProb = 100 - org.changeProb - org.addProb;
             //mutate the remove probability
             amount = Math.random()*4 - 2;
-            org.removeProb += amount.toFixed(2);
+            org.removeProb += amount;
             org.removeProb = Math.min(Math.max(org.removeProb, 0), 100);
             org.addProb = 100 - org.removeProb - org.changeProb;
             org.changeProb = 100 - org.removeProb - org.addProb;

--- a/src/Organism/Organism.js
+++ b/src/Organism/Organism.js
@@ -87,17 +87,17 @@ class Organism {
             var amount;
             //mutate the add probability
             amount = Math.random()*4 - 2;
-            org.addProb += amount;
+            org.addProb += amount.toFixed(2);
             org.changeProb = 100 - org.addProb - org.removeProb;
             org.removeProb = 100 - org.addProb - org.changeProb;
             //mutate the change probability
             amount = Math.random()*4 - 2;
-            org.changeProb += amount;
+            org.changeProb += amount.toFixed(2);
             org.addProb = 100 - org.changeProb - org.removeProb;
             org.removeProb = 100 - org.changeProb - org.addProb;
             //mutate the remove probability
             amount = Math.random()*4 - 2;
-            org.removeProb += amount;
+            org.removeProb += amount.toFixed(2);
             org.addProb = 100 - org.removeProb - org.changeProb;
             org.changeProb = 100 - org.removeProb - org.addProb;
         } 

--- a/src/Organism/Organism.js
+++ b/src/Organism/Organism.js
@@ -22,7 +22,7 @@ class Organism {
         this.move_range = 4;
         this.ignore_brain_for = 0;
         this.mutability = 5;
-        this.addProb = 34;
+        this.addProb = 33;
         this.changeProb = 33;
         this.removeProb = 33;
         this.damage = 0;
@@ -86,21 +86,30 @@ class Organism {
             }
             var amount;
             //mutate the add probability
-            amount = Math.random()*4 - 2;
+            amount = Math.random()*2 - 1;
             org.addProb += amount;
             org.addProb = Math.min(Math.max(org.addProb, 0), 100);
+            org.changeProb -= amount/2;
+            org.removeProb -= amount/2;
+            //fix the probabilities (floating point errors)
             org.changeProb = 100 - org.addProb - org.removeProb;
             org.removeProb = 100 - org.addProb - org.changeProb;
             //mutate the change probability
-            amount = Math.random()*4 - 2;
+            amount = Math.random()*2 - 1;
             org.changeProb += amount;
             org.changeProb = Math.min(Math.max(org.changeProb, 0), 100);
+            org.addProb -= amount/2;
+            org.removeProb -= amount/2;
+            //fix the probabilities (floating point errors)
             org.addProb = 100 - org.changeProb - org.removeProb;
             org.removeProb = 100 - org.changeProb - org.addProb;
             //mutate the remove probability
-            amount = Math.random()*4 - 2;
+            amount = Math.random()*2 - 1;
             org.removeProb += amount;
             org.removeProb = Math.min(Math.max(org.removeProb, 0), 100);
+            org.addProb -= amount/2;
+            org.changeProb -= amount/2;
+            //fix the probabilities (floating point errors)
             org.addProb = 100 - org.removeProb - org.changeProb;
             org.changeProb = 100 - org.removeProb - org.addProb;
         } 

--- a/src/Organism/Organism.js
+++ b/src/Organism/Organism.js
@@ -22,6 +22,9 @@ class Organism {
         this.move_range = 4;
         this.ignore_brain_for = 0;
         this.mutability = 5;
+        this.addProb = 34;
+        this.changeProb = 33;
+        this.removeProb = 33;
         this.damage = 0;
         this.brain = new Brain(this);
         if (parent != null) {
@@ -32,6 +35,9 @@ class Organism {
     inherit(parent) {
         this.move_range = parent.move_range;
         this.mutability = parent.mutability;
+        this.addProb = parent.addProb;
+        this.changeProb = parent.changeProb;
+        this.removeProb = parent.removeProb;
         this.species = parent.species;
         // this.birth_distance = parent.birth_distance;
         for (var c of parent.anatomy.cells){
@@ -78,6 +84,49 @@ class Organism {
                 if (org.mutability < 1)
                     org.mutability = 1;
             }
+            //mutate the add probability
+            if (Math.random() <= 0.5){
+                org.addProb++;
+                org.changeProb -= 0.5;
+                org.removeProb -= 0.5;
+            }else{
+                org.addProb--;
+                org.changeProb += 0.5;
+                org.removeProb += 0.5;
+            }
+            //mutate the change probability
+            if (Math.random() <= 0.5){
+                org.addProb -= 0.5;
+                org.changeProb++;
+                org.removeProb -= 0.5;
+            }else{
+                org.addProb += 0.5;
+                org.changeProb--;
+                org.removeProb += 0.5;
+            }
+            //mutate the remove probability
+            if (Math.random() <= 0.5){
+                org.addProb -= 0.5;
+                org.changeProb -= 0.5;
+                org.removeProb++;
+            }else{
+                org.addProb += 0.5;
+                org.changeProb += 0.5;
+                org.removeProb--;
+            }
+            //fit to the range
+            if (org.addProb > 100)
+                org.addProb = 100;
+            if (org.changeProb > 100)
+                org.changeProb = 100;
+            if (org.removeProb > 100)
+                org.removeProb = 100;
+            if (org.addProb < 0)
+                org.addProb = 0;
+            if (org.changeProb < 0)
+                org.changeProb = 0;
+            if (org.removeProb < 0)
+                org.removeProb = 0;
         } 
         var mutated = false;
         if (Math.random() * 100 <= prob) {
@@ -123,7 +172,7 @@ class Organism {
 
     mutate() {
         let mutated = false;
-        if (this.calcRandomChance(Hyperparams.addProb)) {
+        if (this.calcRandomChance(this.addProb)) {
             let branch = this.anatomy.getRandomCell();
             let state = CellStates.getRandomLivingType();//branch.state;
             let growth_direction = Neighbors.all[Math.floor(Math.random() * Neighbors.all.length)]
@@ -134,13 +183,13 @@ class Organism {
                 this.anatomy.addRandomizedCell(state, c, r);
             }
         }
-        if (this.calcRandomChance(Hyperparams.changeProb)){
+        if (this.calcRandomChance(this.changeProb)){
             let cell = this.anatomy.getRandomCell();
             let state = CellStates.getRandomLivingType();
             this.anatomy.replaceCell(state, cell.loc_col, cell.loc_row);
             mutated = true;
         }
-        if (this.calcRandomChance(Hyperparams.removeProb)){
+        if (this.calcRandomChance(this.removeProb)){
             if(this.anatomy.cells.length > 1) {
                 let cell = this.anatomy.getRandomCell();
                 mutated = this.anatomy.removeCell(cell.loc_col, cell.loc_row);

--- a/src/Organism/Organism.js
+++ b/src/Organism/Organism.js
@@ -88,31 +88,18 @@ class Organism {
             //mutate the add probability
             amount = Math.random()*4 - 2;
             org.addProb += amount;
-            org.changeProb -= amount/2;
-            org.removeProb -= amount/2;
+            org.changeProb -= 100 - org.addProb - org.removeProb;
+            org.removeProb -= 100 - org.addProb - org.changeProb;
             //mutate the change probability
             amount = Math.random()*4 - 2;
             org.changeProb += amount;
-            org.addProb -= amount/2;
-            org.removeProb -= amount/2;
+            org.addProb -= 100 - org.changeProb - org.removeProb;
+            org.removeProb -= 100 - org.changeProb - org.addProb;
             //mutate the remove probability
             amount = Math.random()*4 - 2;
             org.removeProb += amount;
-            org.addProb -= amount/2;
-            org.changeProb -= amount/2;
-            //fit to the range
-            if (org.addProb > 100)
-                org.addProb = 100;
-            if (org.changeProb > 100)
-                org.changeProb = 100;
-            if (org.removeProb > 100)
-                org.removeProb = 100;
-            if (org.addProb < 0)
-                org.addProb = 0;
-            if (org.changeProb < 0)
-                org.changeProb = 0;
-            if (org.removeProb < 0)
-                org.removeProb = 0;
+            org.addProb -= 100 - org.removeProb - org.changeProb;
+            org.changeProb -= 100 - org.removeProb - org.addProb;
         } 
         var mutated = false;
         if (Math.random() * 100 <= prob) {

--- a/src/Organism/Organism.js
+++ b/src/Organism/Organism.js
@@ -88,18 +88,18 @@ class Organism {
             //mutate the add probability
             amount = Math.random()*4 - 2;
             org.addProb += amount;
-            org.changeProb -= 100 - org.addProb - org.removeProb;
-            org.removeProb -= 100 - org.addProb - org.changeProb;
+            org.changeProb = 100 - org.addProb - org.removeProb;
+            org.removeProb = 100 - org.addProb - org.changeProb;
             //mutate the change probability
             amount = Math.random()*4 - 2;
             org.changeProb += amount;
-            org.addProb -= 100 - org.changeProb - org.removeProb;
-            org.removeProb -= 100 - org.changeProb - org.addProb;
+            org.addProb = 100 - org.changeProb - org.removeProb;
+            org.removeProb = 100 - org.changeProb - org.addProb;
             //mutate the remove probability
             amount = Math.random()*4 - 2;
             org.removeProb += amount;
-            org.addProb -= 100 - org.removeProb - org.changeProb;
-            org.changeProb -= 100 - org.removeProb - org.addProb;
+            org.addProb = 100 - org.removeProb - org.changeProb;
+            org.changeProb = 100 - org.removeProb - org.addProb;
         } 
         var mutated = false;
         if (Math.random() * 100 <= prob) {

--- a/src/Organism/Organism.js
+++ b/src/Organism/Organism.js
@@ -84,36 +84,22 @@ class Organism {
                 if (org.mutability < 1)
                     org.mutability = 1;
             }
+            var amount;
             //mutate the add probability
-            if (Math.random() <= 0.5){
-                org.addProb++;
-                org.changeProb -= 0.5;
-                org.removeProb -= 0.5;
-            }else{
-                org.addProb--;
-                org.changeProb += 0.5;
-                org.removeProb += 0.5;
-            }
+            amount = Math.random()*4 - 2;
+            org.addProb += amount;
+            org.changeProb -= amount/2;
+            org.removeProb -= amount/2;
             //mutate the change probability
-            if (Math.random() <= 0.5){
-                org.addProb -= 0.5;
-                org.changeProb++;
-                org.removeProb -= 0.5;
-            }else{
-                org.addProb += 0.5;
-                org.changeProb--;
-                org.removeProb += 0.5;
-            }
+            amount = Math.random()*4 - 2;
+            org.changeProb += amount;
+            org.addProb -= amount/2;
+            org.removeProb -= amount/2;
             //mutate the remove probability
-            if (Math.random() <= 0.5){
-                org.addProb -= 0.5;
-                org.changeProb -= 0.5;
-                org.removeProb++;
-            }else{
-                org.addProb += 0.5;
-                org.changeProb += 0.5;
-                org.removeProb--;
-            }
+            amount = Math.random()*4 - 2;
+            org.removeProb += amount;
+            org.addProb -= amount/2;
+            org.changeProb -= amount/2;
             //fit to the range
             if (org.addProb > 100)
                 org.addProb = 100;

--- a/src/Organism/Organism.js
+++ b/src/Organism/Organism.js
@@ -88,16 +88,19 @@ class Organism {
             //mutate the add probability
             amount = Math.random()*4 - 2;
             org.addProb += amount.toFixed(2);
+            org.addProb = Math.min(Math.max(org.addProb, 0), 100);
             org.changeProb = 100 - org.addProb - org.removeProb;
             org.removeProb = 100 - org.addProb - org.changeProb;
             //mutate the change probability
             amount = Math.random()*4 - 2;
             org.changeProb += amount.toFixed(2);
+            org.changeProb = Math.min(Math.max(org.changeProb, 0), 100);
             org.addProb = 100 - org.changeProb - org.removeProb;
             org.removeProb = 100 - org.changeProb - org.addProb;
             //mutate the remove probability
             amount = Math.random()*4 - 2;
             org.removeProb += amount.toFixed(2);
+            org.removeProb = Math.min(Math.max(org.removeProb, 0), 100);
             org.addProb = 100 - org.removeProb - org.changeProb;
             org.changeProb = 100 - org.removeProb - org.addProb;
         } 

--- a/src/Stats/StatsPanel.js
+++ b/src/Stats/StatsPanel.js
@@ -52,7 +52,13 @@ class StatsPanel {
         $('#org-count').text("Total Population: " + org_count);
         $('#species-count').text("Number of Species: " + FossilRecord.extant_species.length);
         $('#largest-org').text("Largest Organism Ever: " + this.env.largest_cell_count + " cells");
-        $('#avg-mut').text("Average Mutation Rate: " + Math.round(this.env.averageMutability() * 100) / 100);
+        var mutation_info = "Average Mutation Rate: " + this.env.averageMutability().toFixed(2);
+
+        mutation_info += " (Add: " + this.env.avarageAddMutability().toFixed(2) ;
+        mutation_info += ", Change: " + this.env.avarageChangeMutability().toFixed(2);
+        mutation_info += ", Remove: " + this.env.avarageRemoveMutability().toFixed(2) + ")";
+
+        $('#avg-mut').text(mutation_info);
 
 
     }


### PR DESCRIPTION
![mutation-overhaul](https://user-images.githubusercontent.com/29312699/150285725-33b430b4-a74a-4261-9b3d-77272af98032.gif)

Like mutation, the probabilities of mutation types(add, change, remove) can also be mutated by being carried in the organism. 

Added elements to the interface where the user can edit and see the mutation type probabilities of the organism.
**(The empty areas of the interface was used in the most optimal way as It is valuable.)**

Similarly, the probability average of the add, replace, and remove mutation types was added to the statistics.