### PR TITLE
Patch Bug Involving Lifespan and Damage

### DIFF
--- a/src/Organism/Organism.js
+++ b/src/Organism/Organism.js
@@ -251,7 +251,7 @@ class Organism {
     harm() {
         this.damage++;
         if (this.damage >= this.maxHealth() || Hyperparams.instaKill) {
-            this.die();
+            if(this.die) this.die();
         }
     }
 
@@ -274,9 +274,11 @@ class Organism {
     }
 
     update() {
+        if(this.lifetime<0) this.lifetime = 0;
+        if(this.damage<0) this.damage = 0;
         this.lifetime++;
         if (this.lifetime > this.lifespan()) {
-            this.die();
+            if(this.die) this.die();
             return this.living;
         }
         if (this.food_collected >= this.foodNeeded()) {


### PR DESCRIPTION
Setting lifespan and damage to a negative number allows for a higher time alive or more damage taken before death than expected.
Every update, it checks if lifetime or damage are less than 0. If so, then set them to 0.

Note: I haven't updated the `dist` directory to reflect these changes. If you merge this PR into the game, please make sure to re-build it for me.